### PR TITLE
Fix github token permissions for deploy pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,11 +5,16 @@ on:
     branches: [ main ]
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,11 +31,15 @@ jobs:
       - name: Build web
         run: npm run build:web
 
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: dist
 
       - name: Deploy to GitHub Pages
+        id: deployment
         uses: actions/deploy-pages@v4
 


### PR DESCRIPTION
Fix OIDC error and enable GitHub Pages deployment by adding required permissions and configuration.

The previous workflow failed with an OIDC error (`Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`) and lacked the necessary permissions and steps for `actions/deploy-pages@v4` to function correctly. This PR grants `id-token: write` and `pages: write` permissions, adds the `configure-pages` step, and sets the `github-pages` environment, aligning the workflow with the recommended setup for GitHub Pages deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-094cf9b1-8f07-43b9-a0a7-5ec3a6334fd6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-094cf9b1-8f07-43b9-a0a7-5ec3a6334fd6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

