### PR TITLE
Fetch and store feed metadata

### DIFF
--- a/__tests__/parser.test.ts
+++ b/__tests__/parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import { parseFeedText, rssToArticles } from '@/lib/parser';
+import { extractFaviconFromHtml } from '@/lib/site';
 
 const sampleFeed = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">
@@ -23,6 +24,15 @@ describe('parser', () => {
     expect(articles[0].title).toContain('Post 1');
     expect(articles[0].link).toContain('post-1');
     expect(typeof articles[0].content).toBe('string');
+  });
+
+  it('extracts favicon from HTML head', () => {
+    const html = `<!DOCTYPE html><html><head>
+      <link rel="icon" href="/favicon.ico" />
+    </head><body></body></html>`;
+    const base = 'https://example.com/some/page';
+    const fav = extractFaviconFromHtml(html, base);
+    expect(fav).toBe('https://example.com/favicon.ico');
   });
 });
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Alert, FlatList, Pressable, StyleSheet, TextInput } from 'react-native';
+import { Alert, FlatList, Pressable, StyleSheet, TextInput, Image } from 'react-native';
 import { Text, View } from '@/components/Themed';
 import { useAppContext } from '@/context/AppContext';
 import { FeedInfo } from '@/lib/types';
@@ -27,6 +27,9 @@ export default function FeedsScreen() {
 
   const renderItem = ({ item }: { item: FeedInfo }) => (
     <View style={styles.feedRow} testID="feed-row">
+      {item.faviconUrl ? (
+        <Image source={{ uri: item.faviconUrl }} style={styles.favicon} testID="feed-favicon" />
+      ) : null}
       <Pressable accessibilityRole="button" testID="feed-open" onPress={() => router.push({ pathname: '/feed/[id]', params: { id: item.id } })} style={{ flex: 1 }}>
         <View style={{ flex: 1 }}>
           <Text style={styles.feedTitle}>{item.title ?? item.url}</Text>
@@ -85,6 +88,7 @@ const styles = StyleSheet.create({
   input: { flex: 1, borderWidth: 1, borderColor: '#ccc', borderRadius: 6, paddingHorizontal: 10, height: 40 },
   addButton: { color: '#007aff', paddingHorizontal: 8, paddingVertical: 8 },
   feedRow: { flexDirection: 'row', alignItems: 'center', paddingVertical: 10 },
+  favicon: { width: 20, height: 20, marginRight: 8, borderRadius: 4 },
   feedTitle: { fontSize: 16, fontWeight: '600' },
   feedDesc: { color: '#666' },
   separator: { height: 1, backgroundColor: '#eee' },

--- a/cypress/e2e/feed-metadata.cy.ts
+++ b/cypress/e2e/feed-metadata.cy.ts
@@ -1,0 +1,28 @@
+describe('Feed metadata (title, description, favicon)', () => {
+  it('saves and displays feed title, description, and favicon after adding', () => {
+    cy.stubHnRss();
+    cy.visit('/');
+    cy.findByTestId('feed-url-input').clear().type('https://hnrss.org/frontpage');
+    cy.findByTestId('add-feed-button').click();
+
+    // Title should be the feed title from XML
+    cy.findAllByTestId('feed-row').first().within(() => {
+      cy.contains('HN Frontpage');
+      cy.findByText('Frontpage links');
+      cy.findByTestId('feed-favicon').should('exist');
+    });
+
+    // Assert that the state persisted includes faviconUrl, title, and description
+    cy.window().should((win: any) => {
+      const raw = win.localStorage.getItem('rss_reader_state_v1');
+      expect(raw, 'state exists').to.be.a('string');
+      const state = JSON.parse(raw);
+      expect(state.feeds, 'feeds array').to.be.an('array').and.to.have.length.greaterThan(0);
+      const f = state.feeds[0];
+      expect(f.title).to.eq('HN Frontpage');
+      expect(f.description).to.eq('Frontpage links');
+      expect(f.faviconUrl).to.contain('news.ycombinator.com/favicon.ico');
+    });
+  });
+});
+

--- a/cypress/fixtures/hn-home.html
+++ b/cypress/fixtures/hn-home.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hacker News</title>
+    <link rel="icon" href="https://news.ycombinator.com/favicon.ico" />
+  </head>
+  <body>
+    <h1>HN</h1>
+  </body>
+</html>
+

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -9,4 +9,7 @@ Cypress.Commands.add('stubHnRss', () => {
   // AllOrigins fallback
   cy.intercept('GET', 'https://api.allorigins.win/raw?*hnrss.org/newest*', { fixture: 'hn-newest.xml' }).as('hnNewestAlt');
   cy.intercept('GET', 'https://api.allorigins.win/raw?*hnrss.org/frontpage*', { fixture: 'hn-frontpage.xml' }).as('hnFrontAlt');
+  // Site homepage for favicon discovery
+  cy.intercept('GET', 'https://news.ycombinator.com/', { fixture: 'hn-home.html', headers: { 'content-type': 'text/html' } }).as('hnHome');
+  cy.intercept('GET', 'https://api.allorigins.win/raw?*news.ycombinator.com*', { fixture: 'hn-home.html', headers: { 'content-type': 'text/html' } }).as('hnHomeAlt');
 });

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -92,6 +92,7 @@ export async function getFeedInfo(feedText: string) {
   return {
     title: feedInfo.title,
     description: feedInfo.description,
+    link: feedInfo.link,
     lastBuildDate: convertDateStringToDate(lastBuild),
   };
 }

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,21 @@
+export function extractFaviconFromHtml(html: string, baseUrl: string): string | undefined {
+  const relIconRegex = /<link[^>]+rel=["']?([^"'>]+)["']?[^>]*href=["']([^"']+)["'][^>]*>/gi;
+  const candidates: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = relIconRegex.exec(html))) {
+    const relValue = match[1]?.toLowerCase() || '';
+    const hrefValue = match[2];
+    if (!hrefValue) continue;
+    if (/(^|\s)(icon|shortcut icon|apple-touch-icon|apple-touch-icon-precomposed|mask-icon)(\s|$)/.test(relValue)) {
+      candidates.push(hrefValue);
+    }
+  }
+  const href = candidates[0] || '/favicon.ico';
+  try {
+    const url = new URL(href, baseUrl);
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -15,6 +15,8 @@ export type FeedInfo = {
   description?: string;
   lastBuildDate?: string; // ISO string
   nextPageUrl?: string;
+  siteUrl?: string;
+  faviconUrl?: string;
 };
 
 export type Bookmark = {


### PR DESCRIPTION
Add feed title, description, and favicon extraction and display to provide richer information for each feed.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d87cd9d-fa65-4b2c-88ae-9caccb869ebd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2d87cd9d-fa65-4b2c-88ae-9caccb869ebd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

